### PR TITLE
refactor: Moved podcasts support to cubapod.net

### DIFF
--- a/src/components/Podcast.svelte
+++ b/src/components/Podcast.svelte
@@ -8,7 +8,7 @@
 	let podcast
 	let isActive = ''
 
-	const url = `https://raw.githubusercontent.com/lugodev/cuban-podcasts-feedr-bot/master/src/feeds.json`
+	const url = `https://cubapod.net/feeds.json`
 
     fetch( url ).then( r=>r.json() ).then( data =>{ 
     	podcasts = data 


### PR DESCRIPTION
@sotoplatero I've migrated the podcasts directory to `cubapod.net`, this PR keeps the support for Vistazo, exposing the JSON file as before. I'll be updating it every time a new podcast is added to the directory.